### PR TITLE
Lowercase "TRACK_SLUG" to fix Docker buildx issue where tag must be lowercase.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: exercism/TRACK_SLUG-analyzer
+          tags: exercism/replace-this-with-the-track-slug-analyzer
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/TRACK_README.md
+++ b/TRACK_README.md
@@ -1,6 +1,6 @@
-# Exercism TRACK_NAME analyzer
+# Exercism replace-this-with-the-track-name analyzer
 
-The Docker image to automatically run tests on TRACK_NAME solutions submitted to [Exercism].
+The Docker image to automatically run tests on replace-this-with-the-track-name solutions submitted to [Exercism].
 
 ## Getting started
 

--- a/bin/benchmark-in-docker.sh
+++ b/bin/benchmark-in-docker.sh
@@ -27,7 +27,7 @@ required_tool hyperfine
 
 # Pre-build the Docker image
 if [ -z "${SKIP_DOCKER_BUILD}" ]; then
-  docker build --rm -t exercism/TRACK_SLUG-test-runner .
+  docker build --rm -t exercism/replace-this-with-the-track-slug-test-runner .
 else
   echo "Skipping docker build because SKIP_DOCKER_BUILD is set."
 fi

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -39,12 +39,12 @@ REPO_DIR=$(mktemp -d)
 cp -a . "${REPO_DIR}"
 cd "${REPO_DIR}" || die "Failed to cd to ${REPO_DIR}"
 
-for file in $(git grep --files-with-matches TRACK_SLUG); do
-    sed -i "s/TRACK_SLUG/${SLUG}/g" "${file}"
+for file in $(git grep --files-with-matches replace-this-with-the-track-slug); do
+    sed -i "s/replace-this-with-the-track-slug/${SLUG}/g" "${file}"
 done
 
-for file in $(git grep --files-with-matches TRACK_NAME); do
-    sed -i "s/TRACK_NAME/${LANGUAGE}/g" "${file}"
+for file in $(git grep --files-with-matches replace-this-with-the-track-name); do
+    sed -i "s/replace-this-with-the-track-name/${LANGUAGE}/g" "${file}"
 done
 
 rm -f bin/bootstrap.sh

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -33,7 +33,7 @@ output_dir=$(realpath "${3%/}")
 mkdir -p "${output_dir}"
 
 # Build the Docker image
-docker build --rm -t exercism/TRACK_SLUG-analyzer .
+docker build --rm -t exercism/replace-this-with-the-track-slug-analyzer .
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \
@@ -43,4 +43,4 @@ docker run \
     --mount type=bind,src="${solution_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
     --mount type=tmpfs,dst=/tmp \
-    exercism/TRACK_SLUG-analyzer "${slug}" /solution /output 
+    exercism/replace-this-with-the-track-slug-analyzer "${slug}" /solution /output 

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -16,7 +16,7 @@
 set -e
 
 # Build the Docker image
-docker build --rm -t exercism/TRACK_SLUG-analyzer .
+docker build --rm -t exercism/replace-this-with-the-track-slug-analyzer .
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \
@@ -28,4 +28,4 @@ docker run \
     --volume "${PWD}/bin/run-tests.sh:/opt/analyzer/bin/run-tests.sh" \
     --workdir /opt/analyzer \
     --entrypoint /opt/analyzer/bin/run-tests.sh \
-    exercism/TRACK_SLUG-analyzer
+    exercism/replace-this-with-the-track-slug-analyzer


### PR DESCRIPTION


The CI has a "Build Docker image and store in cache step". That step executes `docker buildx build [..] --tag exercism/TRACK_SLUG-analyzer`. Docker complains, `Error: buildx failed with: ERROR: invalid tag "exercism/TRACK_SLUG-analyzer": repository name must be lowercase`. This commit replaces `TRACK_SLUG` with `track_slug`. This repo did not previously contain `track_slug` anywhere so this should not have any unintended matching side effects.